### PR TITLE
use prettierrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,10 +114,9 @@ module.exports = {
     ],
     "prettier/prettier": [
       "error",
+      {},
       {
-        "trailingComma": "es5",
-        "singleQuote": true,
-        "printWidth": 80,
+        "usePrettierrc": true
       }
     ],
     "jsx-a11y/href-no-hash": "off",

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "trailingComma": "es5",
+    "singleQuote": true,
+    "printWidth": 80
+}


### PR DESCRIPTION
This explicitly moves prettier rules to a `.prettierrc` file.

Previously:
The prettier rules in the `.eslintrc` file of this package will override rules provided by a user in a `.prettierrc` file, causing potential confusion.

Now:
Users can override the prettier rules set by this package by defining their own prettier config file (by following https://prettier.io/docs/en/configuration.html#docsNav)

