### PR TITLE
Stop editor formatting on save for .jsx files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,8 +117,11 @@ Once you have done one, or both, of the above installs. You probably want your e
   ```js
     // These are all my auto-save configs
   "editor.formatOnSave": true,
-  // turn it off for JS, we will do this via eslint
+  // turn it off for JS and JSX, we will do this via eslint
   "[javascript]": {
+    "editor.formatOnSave": false
+  },
+  "[javascriptreact]": {
     "editor.formatOnSave": false
   },
   // tell the ESLint plugin to run on save


### PR DESCRIPTION
The editor still attempts to format on save for JSX even when it's disabled via prettier.disableLanguages. Unfortunately you can't have multiple languages for language-specific rules.

Explicitly disabling formatOnSave for `javascriptreact` fixes this issue.