### PR TITLE
Add underscore to the list of allowed unused args

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
       1,
       {
         "ignoreSiblings": true,
-        "argsIgnorePattern": "res|next|^err"
+        "argsIgnorePattern": "res|next|^err|_"
       }
     ],
     "prefer-const": [


### PR DESCRIPTION
Hey Wes. Lots of devs use `_` to denote args they don't intend to use. You think it'll be useful to add it to the `argsIgnorePattern` list of the `no-unused-vars` rule?