### PR TITLE
Switch ignoreSiblings to ignoreRestSiblings in no-unused-vars config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
     "no-unused-vars": [
       1,
       {
-        "ignoreSiblings": true,
+        "ignoreRestSiblings": true,
         "argsIgnorePattern": "res|next|^err"
       }
     ],


### PR DESCRIPTION
ignoreSiblings is not a property of no-unused-vars and actually causes an error in recent versions of eslint since [this commit which now disallows extra properties in the no-unused-vars config](https://github.com/eslint/eslint/commit/638a6d6be18b4a37cfdc7223e1f5acd3718694be)

The correct property is ignoreRestSiblings as per https://eslint.org/docs/rules/no-unused-vars#ignorerestsiblings

At the moment, eslint-config-wesbos doesn't work under eslint 7.5.0 but this should fix it. Unless I've misunderstood something, ignoreSiblings was never a thing? But until they tightened up the rules around additional config properities it was sailing under radar.

Thanks for the config, keep up the good work :-)