### PR TITLE
update peer-dep eslint-plugin-html

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint": "^6.1.0",
     "eslint-config-airbnb": "^18.0.0",
     "eslint-config-prettier": "^4.1.0",
-    "eslint-plugin-html": "^5.0.3",
+    "eslint-plugin-html": "^6.0.3",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.0.1",


### PR DESCRIPTION
@wesbos I messed up 🤣  - I only updated the `devDependency` version of the package, I forgot that in a plugin like this there are `peerDependencies`. 

I just tried the command `npx install-peerdeps eslint-config-wesbos` noticed it was still installing the old `5.0.3` version. I updated the `peerDependency` to be `6.0.3`.