### PR TITLE
Add asset option for label-control fix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,6 +69,12 @@ module.exports = {
     'react/forbid-prop-types': 0,
     'react/no-unescaped-entities': 0,
     'jsx-a11y/accessible-emoji': 0,
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      {
+        "assert": "either"
+      }
+    ],
     'react/require-default-props': 0,
     'react/jsx-filename-extension': [
       1,


### PR DESCRIPTION
This `jsx-a11y/label-has-associated-control` error can be fixed by `assert`ing that it `either` respects `both` (control nested inside label), `htmlFor` (with the `htmlFor` attribute) or `either` one of them.

https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/632