### PR TITLE
Disable react/jsx-props-no-spreading

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,11 +69,11 @@ module.exports = {
     'react/forbid-prop-types': 0,
     'react/no-unescaped-entities': 0,
     'jsx-a11y/accessible-emoji': 0,
-    "jsx-a11y/label-has-associated-control": [
-      "error",
+    'jsx-a11y/label-has-associated-control': [
+      'error',
       {
-        "assert": "either"
-      }
+        assert: 'either',
+      },
     ],
     'react/require-default-props': 0,
     'react/jsx-filename-extension': [
@@ -82,6 +82,7 @@ module.exports = {
         extensions: ['.js', '.jsx'],
       },
     ],
+    'react/jsx-props-no-spreading': 0,
     radix: 0,
     'no-shadow': [
       2,


### PR DESCRIPTION
and auto format fixed some inconsistencies

This removes the eslint error when following your Gatsby course:

```jsx
import React from 'react';
import Layout from './src/components/Layout';

export function wrapPageElement({ element, props }) {
  return <Layout {...props}>{element}</Layout>;
}
```