### PR TITLE
Update VS Code settings to include changing the default tab size to 2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,6 +132,8 @@ Once you have done one, or both, of the above installs. You probably want your e
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   },
+  // Change the default VS Code tab size to 2
+  "editor.tabSize": 2,
   // Optional BUT IMPORTANT: If you have the prettier extension enabled for other languages like CSS and HTML, turn it off for JS since we are doing it through Eslint already
   "prettier.disableLanguages": ["javascript", "javascriptreact"],
   ```


### PR DESCRIPTION
I ran into an issue where my ESLint was always freaking out because VS Code was set up with a tab size of 4, when it expected 2. It always fixed when saving, but while typing it would constantly show an error on every line. 

Not sure you want this setting here, so feel free to propose changes or close this request. 