### PR TITLE
Update .eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['airbnb', 'prettier', 'prettier/react'],
+  extends: ['airbnb', 'prettier'],
   parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2020,


### PR DESCRIPTION
I was running into this error: Failed to load config "prettier/react" to extend. Removing 'prettier/react' have revolved the problem.

In [version 8.0.0](https://github.com/prettier/eslint-config-prettier/blob/0dd2a7ed26f5ce2cd35ff242228afaaf2fe2de2b/CHANGELOG.md#version-800-2021-02-21) of eslint-config-prettier extending "prettier" is enough it includes all the React rules and rules for other plugins.