### PR TITLE
Update typescript.js for eslint-config-prettier v8

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: [
     'plugin:@typescript-eslint/recommended', // Uses rules from `@typescript-eslint/eslint-plugin`,
-    'prettier/@typescript-eslint', // Use `eslint-config-prettier` to override conflicting rules from `@typescript-eslint/eslint-plugin`
+    'prettier', // Use `eslint-config-prettier` to override conflicting rules from `@typescript-eslint/eslint-plugin`
     'airbnb-typescript',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',


### PR DESCRIPTION
Make typescript.js compatible with eslint-config-prettier v8. See `https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21`