### PR TITLE
Changes the way Prettier gets disabled on Javascript, JavaScript React

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,10 +121,15 @@ Once you have done one, or both, of the above installs. You probably want your e
   "editor.formatOnSave": true,
   // turn it off for JS and JSX, we will do this via eslint
   "[javascript]": {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": false,
+    // Optional BUT IMPORTANT: If you have the prettier extension enabled for other languages like CSS and HTML, turn it off for JS and JSX since we are doing it through Eslint already
+    "editor.defaultFormatter": null
+
   },
   "[javascriptreact]": {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": null
+
   },
   // show eslint icon at bottom toolbar
   "eslint.alwaysShowStatus": true,
@@ -132,8 +137,6 @@ Once you have done one, or both, of the above installs. You probably want your e
   "editor.codeActionsOnSave": {
     "source.fixAll": true
   },
-  // Optional BUT IMPORTANT: If you have the prettier extension enabled for other languages like CSS and HTML, turn it off for JS since we are doing it through Eslint already
-  "prettier.disableLanguages": ["javascript", "javascriptreact"],
   ```
 
 After attempting to lint your file for the first time, you may need to click on 'ESLint' in the bottom right and select 'Allow Everywhere' in the alert window. 


### PR DESCRIPTION
"prettier.disableLanguages" Is no longer supported on VSCode.
This is the proper way to disable Prettier now.
https://github.com/prettier/prettier-vscode