### PR TITLE
Prettier extension disabling fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -121,10 +121,12 @@ Once you have done one, or both, of the above installs. You probably want your e
   "editor.formatOnSave": true,
   // turn it off for JS and JSX, we will do this via eslint
   "[javascript]": {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[javascriptreact]": {
-    "editor.formatOnSave": false
+    "editor.formatOnSave": false,
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   // show eslint icon at bottom toolbar
   "eslint.alwaysShowStatus": true,
@@ -133,7 +135,7 @@ Once you have done one, or both, of the above installs. You probably want your e
     "source.fixAll": true
   },
   // Optional BUT IMPORTANT: If you have the prettier extension enabled for other languages like CSS and HTML, turn it off for JS since we are doing it through Eslint already
-  "prettier.disableLanguages": ["javascript", "javascriptreact"],
+  // "prettier.disableLanguages": ["javascript", "javascriptreact"], 
   ```
 
 After attempting to lint your file for the first time, you may need to click on 'ESLint' in the bottom right and select 'Allow Everywhere' in the alert window. 

--- a/readme.md
+++ b/readme.md
@@ -122,11 +122,9 @@ Once you have done one, or both, of the above installs. You probably want your e
   // turn it off for JS and JSX, we will do this via eslint
   "[javascript]": {
     "editor.formatOnSave": false,
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[javascriptreact]": {
     "editor.formatOnSave": false,
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   // show eslint icon at bottom toolbar
   "eslint.alwaysShowStatus": true,
@@ -135,7 +133,12 @@ Once you have done one, or both, of the above installs. You probably want your e
     "source.fixAll": true
   },
   // Optional BUT IMPORTANT: If you have the prettier extension enabled for other languages like CSS and HTML, turn it off for JS since we are doing it through Eslint already
-  // "prettier.disableLanguages": ["javascript", "javascriptreact"], 
+   "[javascript]": {
+   "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[javascriptreact]": {
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  }
   ```
 
 After attempting to lint your file for the first time, you may need to click on 'ESLint' in the bottom right and select 'Allow Everywhere' in the alert window. 

--- a/readme.md
+++ b/readme.md
@@ -121,10 +121,10 @@ Once you have done one, or both, of the above installs. You probably want your e
   "editor.formatOnSave": true,
   // turn it off for JS and JSX, we will do this via eslint
   "[javascript]": {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": false
   },
   "[javascriptreact]": {
-    "editor.formatOnSave": false,
+    "editor.formatOnSave": false
   },
   // show eslint icon at bottom toolbar
   "eslint.alwaysShowStatus": true,


### PR DESCRIPTION
A fix for the error message:

This feature is no longer supported. Instead, configure VS Code [default formatters](https://github.com/prettier/prettier-vscode#default-formatter) or use .prettierignore.

On adding `"prettier.disableLanguages": ["javascript", "javascriptreact"],` in settings.json