### PR TITLE
Avoid duplicate errors (eslint + eslint typescript)

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -24,6 +24,8 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-explicit-any': 'off',
+    'no-unused-vars': 0,
+    '@typescript-eslint/no-unused-vars': [1, { ignoreRestSiblings: true }],
     'no-redeclare': 'off',
     '@typescript-eslint/no-redeclare': [
       'warn',
@@ -31,6 +33,7 @@ module.exports = {
         ignoreDeclarationMerge: true,
       },
     ],
+    'no-unused-vars': 0,
     '@typescript-eslint/no-floating-promises': 'off',
   },
   parserOptions: {


### PR DESCRIPTION
It avoids duplicate errors (one from eslint, one from typescript). As recommended: https://typescript-eslint.io/rules/no-unused-vars