### PR TITLE
Amend source.fixAll.eslint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -137,8 +137,8 @@ Once you have done one, or both, of the above installs. You probably want your e
 },
 // tell the ESLint plugin to run on save
 "editor.codeActionsOnSave": {
-  "source.fixAll": true
-}
+  "source.fixAll.eslint": true
+},
 ```
 
 After attempting to lint your file for the first time, you may need to click on 'ESLint' in the bottom right and select 'Allow Everywhere' in the alert window.


### PR DESCRIPTION
For VS Code's ESLint plugin, the `source.fixAll` has [since been replaced](https://github.com/microsoft/vscode-eslint/issues/833#issuecomment-566442561) in favour of `source.fixAll.eslint`. As such, the updated setting should read: 

```js
"editor.codeActionsOnSave": {
  "source.fixAll.eslint": true
},
```

Cheers.